### PR TITLE
Tests for metagraph cuda

### DIFF
--- a/metagraph_cuda/algorithms/pagerank.py
+++ b/metagraph_cuda/algorithms/pagerank.py
@@ -5,19 +5,20 @@ import numpy as np
 
 if has_cugraph:
     import cugraph
+    from ..types import CuGraph
 
     from metagraph.plugins.numpy.types import NumpyNodes
 
     @concrete_algorithm("link_analysis.pagerank")
     def cugraph_pagerank(
-        graph: cugraph.DiGraph,
+        graph: CuGraph,
         damping: float = 0.85,
         maxiter: int = 50,
         tolerance: float = 1e-05,
     ) -> NumpyNodes:
         pagerank = cugraph.pagerank(
-            graph, alpha=damping, max_iter=maxiter, tol=tolerance
+            graph.value, alpha=damping, max_iter=maxiter, tol=tolerance
         )
-        out = np.full((graph.number_of_nodes(),), np.nan)
+        out = np.full((graph.value.number_of_nodes(),), np.nan)
         out[pagerank["vertex"]] = pagerank["pagerank"]
         return NumpyNodes(out, missing_value=np.nan)

--- a/metagraph_cuda/algorithms/triangle_count.py
+++ b/metagraph_cuda/algorithms/triangle_count.py
@@ -4,7 +4,8 @@ from ..registry import has_cugraph
 
 if has_cugraph:
     import cugraph
+    from ..types import CuGraph
 
     @concrete_algorithm("cluster.triangle_count")
-    def auto_cugraph_triangle_count(graph: cugraph.Graph) -> int:
-        return cugraph.triangles(graph) // 3
+    def cugraph_triangle_count(graph: CuGraph) -> int:
+        return cugraph.triangles(graph.value) // 3

--- a/metagraph_cuda/tests/algorithms/test_pagerank.py
+++ b/metagraph_cuda/tests/algorithms/test_pagerank.py
@@ -42,18 +42,13 @@ def test_pagerank_on_cugraph_digraph():
     gdf = cudf.read_csv(
         csv_file, names=["Source", "Destination"], dtype=["int32", "int32"]
     )
-    g = cugraph.DiGraph()
-    g.from_cudf_edgelist(gdf, source="Source", destination="Destination")
+    cugraph_digraph = cugraph.DiGraph()
+    cugraph_digraph.from_cudf_edgelist(gdf, source="Source", destination="Destination")
     # Verify Graph Data
-    assert g.number_of_vertices() == 4
-    assert g.number_of_edges() == 5
-    # Verify Resolver Support For Graph Type
-    g_type = type(g)
-    assert g_type == cugraph.DiGraph
-    assert g_type in r.class_to_concrete
-    g_concrete_type = r.class_to_concrete[g_type]
-    assert g_concrete_type in r.concrete_types
+    assert cugraph_digraph.number_of_vertices() == 4
+    assert cugraph_digraph.number_of_edges() == 5
     # Verify Algorithm Presence
+    g = r.wrapper.Graph.CuGraph(cugraph_digraph)
     assert r.find_algorithm("link_analysis.pagerank", g)
     # Verify PageRank Result Type & Result
     rankings = r.algo.link_analysis.pagerank(g)

--- a/metagraph_cuda/tests/algorithms/test_triangle_count.py
+++ b/metagraph_cuda/tests/algorithms/test_triangle_count.py
@@ -41,19 +41,15 @@ def test_triangle_count_on_cugraph_digraph():
     gdf = cudf.read_csv(
         csv_file, names=["Source", "Destination"], dtype=["int32", "int32"]
     )
-    g = cugraph.Graph()
-    g.from_cudf_edgelist(gdf, source="Source", destination="Destination")
+    cugraph_graph = cugraph.Graph()
+    cugraph_graph.from_cudf_edgelist(gdf, source="Source", destination="Destination")
     # Verify Graph Data
-    assert g.number_of_vertices() == 8
-    assert g.number_of_edges() == 11
-    # Verify Resolver Support For Graph Type
-    g_type = type(g)
-    assert g_type == cugraph.Graph
-    assert g_type in r.class_to_concrete
-    g_concrete_type = r.class_to_concrete[g_type]
-    assert g_concrete_type in r.concrete_types
+    assert cugraph_graph.number_of_vertices() == 8
+    assert cugraph_graph.number_of_edges() == 11
     # Verify Algorithm Presence
+    g = r.wrapper.Graph.CuGraph(cugraph_graph)
     assert r.find_algorithm_exact("cluster.triangle_count", g)
     # Verify Triangle Count Result Type
     number_of_triangles = r.algo.cluster.triangle_count(g)
+    assert number_of_triangles == 5
     assert isinstance(number_of_triangles, int)

--- a/metagraph_cuda/translators.py
+++ b/metagraph_cuda/translators.py
@@ -4,17 +4,13 @@ from metagraph.plugins import has_pandas
 
 if has_cudf and has_cugraph:
     import cugraph
-    from .types import CuDFEdgeList, AutoCuGraphType, CuGraph
+    from .types import CuDFEdgeList, CuGraph
 
     @translator
-    def translate_graph_cudfedge2cugraph(x: CuDFEdgeList, **props) -> AutoCuGraphType:
-        g = cugraph.Graph()
-        g.from_cudf_edgelist(x.value, x.src_label, x.dest_label)
-        return g
-
-    @translator
-    def translate_graph_cugraph2autocugraph(x: CuGraph, **props) -> AutoCuGraphType:
-        return x.value
+    def translate_graph_cudfedge2cugraph(x: CuDFEdgeList, **props) -> CuGraph:
+        cugraph_graph = cugraph.Graph()
+        cugraph_graph.from_cudf_edgelist(x.value, x.src_label, x.dest_label)
+        return CuGraph(cugraph_graph)
 
 
 if has_pandas and has_cudf:


### PR DESCRIPTION
This PR contains the addition of tests for triangle count and PageRank. 

They are located in `metagraph-cuda/metagraph_cuda/tests/algorithms/`.

There are 4 tests for triangle count. 
* This PR includes are two types of triangle count tests for each supported triangle count input (they current ones are `cugraph.structure.graph.DiGraph` and `metagraph.plugins.scipy.types.ScipyAdjacencyMatrix`).
* The two types of triangle tests are:
  * Triangle count on a 3-node fully connected graph.
  * Triangle count on a larger fully connected graph. 

All the page rank tests test PageRank on various sized fully-connected graphs and verifies that all the nodes have a similar rank (the standard deviation is less than 1e-8).