### PR TITLE
Implement Bipartite Graphs for CuGraph plugin

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -29,5 +29,8 @@ dependencies:
   - numba
   - cupy
   - cudf
-  - cugraph=0.14.*
+  - cugraph=0.15.*
   - cudatoolkit=10.1
+  - dask-cudf
+  - dask-cuda
+

--- a/metagraph_cuda/plugins/cudf/translators.py
+++ b/metagraph_cuda/plugins/cudf/translators.py
@@ -49,7 +49,7 @@ if has_cudf:
     def translate_nodes_cudfnodeset2pythonnodeset(
         x: CuDFNodeSet, **props
     ) -> PythonNodeSet:
-        return PythonNodeSet(set(x.value.index))
+        return PythonNodeSet(set(x.value.index.to_pandas()))
 
     @translator
     def translate_nodes_pythonnodeset2cudfnodeset(
@@ -129,7 +129,7 @@ if has_cudf:
             # O(n log n) sort, but n is small since not dense
             df_index_sorted = x.value.sort_index()
             data = cupy.asnumpy(df_index_sorted[x.value_label].values)
-            node_ids = dict(map(reversed, enumerate(df_index_sorted.index)))
+            node_ids = dict(map(reversed, enumerate(df_index_sorted.index.values_host)))
             mask = None
         return NumpyNodeMap(data, mask=mask, node_ids=node_ids)
 
@@ -269,8 +269,8 @@ if has_cudf and has_scipy:
         num_nodes = len(node_list)
         id2pos = dict(map(reversed, enumerate(node_list)))
         get_id_pos = lambda node_id: id2pos[node_id]
-        source_positions = list(map(get_id_pos, x.value[x.src_label].values.tolist()))
-        target_positions = list(map(get_id_pos, x.value[x.dst_label].values.tolist()))
+        source_positions = list(map(get_id_pos, x.value[x.src_label].values_host))
+        target_positions = list(map(get_id_pos, x.value[x.dst_label].values_host))
         if not is_directed:
             source_positions, target_positions = (
                 source_positions + target_positions,
@@ -296,8 +296,8 @@ if has_cudf and has_scipy:
         num_nodes = len(node_list)
         id2pos = dict(map(reversed, enumerate(node_list)))
         get_id_pos = lambda node_id: id2pos[node_id]
-        source_positions = list(map(get_id_pos, x.value[x.src_label].tolist()))
-        target_positions = list(map(get_id_pos, x.value[x.dst_label].tolist()))
+        source_positions = list(map(get_id_pos, x.value[x.src_label].values_host))
+        target_positions = list(map(get_id_pos, x.value[x.dst_label].values_host))
         weights = cupy.asnumpy(x.value[x.weight_label].values)
         if not is_directed:
             source_positions, target_positions = (

--- a/metagraph_cuda/plugins/cudf/types.py
+++ b/metagraph_cuda/plugins/cudf/types.py
@@ -111,7 +111,7 @@ if has_cudf:
     class CuDFNodeMap(NodeMapWrapper, abstract=NodeMap):
         """
         CuDFNodeMap stores data in a cudf.DataFrame where the index corresponds go the node ids
-        and the entries in the column with the name specified by value_label correspond to 
+        and the entries in the column with the name specified by value_label correspond to
         the mapped values.
         """
 
@@ -168,9 +168,11 @@ if has_cudf:
                 ), f"abstract property mismatch: {aprops1} != {aprops2}"
                 d1, d2 = obj1.value, obj2.value
                 if aprops1.get("dtype") == "float":
-                    assert all(cupy.isclose(d1[obj1.value_label], d2[obj2.value_label]))
+                    assert (
+                        cupy.isclose(d1[obj1.value_label], d2[obj2.value_label])
+                    ).all()
                 else:
-                    assert all(d1[obj1.value_label] == d2[obj2.value_label])
+                    assert (d1[obj1.value_label] == d2[obj2.value_label]).all()
 
     class CuDFEdgeSet(EdgeSetWrapper, abstract=EdgeSet):
         def __init__(
@@ -337,7 +339,7 @@ if has_cudf:
             return len(self.value)
 
         def __iter__(self):
-            return iter(self.value)
+            return iter(self.value.values_host)
 
         def __contains__(self, item):
             return item in self.value.index
@@ -361,4 +363,4 @@ if has_cudf:
                 ), f"abstract property mismatch: {aprops1} != {aprops2}"
                 v1, v2 = obj1.value, obj2.value
                 assert len(v1) == len(v2), f"size mismatch: {len(v1)} != {len(v2)}"
-                assert all(v1 == v2), f"node sets do not match"
+                assert (v1 == v2).all(), f"node sets do not match"

--- a/metagraph_cuda/plugins/cugraph/algorithms.py
+++ b/metagraph_cuda/plugins/cugraph/algorithms.py
@@ -143,7 +143,7 @@ if has_cugraph:
         label_df = label_df.set_index("vertex")
         if graph.nodes is not None:
             orphan_mask: cupy.ndarray = ~graph.nodes.value.index.isin(label_df.index)
-            orphan_nodes = graph.nodes.data.index[orphan_mask]
+            orphan_nodes = graph.nodes.value.data.index[orphan_mask]
             orphan_count = orphan_mask.astype(int).sum().item()
             max_label = label_df.vertex.max()
             orphan_labels = cupy.arange(max_label + 1, max_label + 1 + orphan_count)

--- a/metagraph_cuda/plugins/cugraph/algorithms.py
+++ b/metagraph_cuda/plugins/cugraph/algorithms.py
@@ -142,7 +142,7 @@ if has_cugraph:
         label_df, modularity_score = cugraph.louvain(graph.edges.value)
         label_df = label_df.set_index("vertex")
         if graph.nodes is not None:
-            orphan_mask: cupy.ndarray = ~graph.nodes.index.isin(label_df.index)
+            orphan_mask: cupy.ndarray = ~graph.nodes.value.index.isin(label_df.index)
             orpha_nodes = nodes.data.index[orphan_mask]
             orphan_count = orphan_mask.astype(int).sum().item()
             max_label = label_df.vertex.max()

--- a/metagraph_cuda/plugins/cugraph/algorithms.py
+++ b/metagraph_cuda/plugins/cugraph/algorithms.py
@@ -143,11 +143,11 @@ if has_cugraph:
         label_df = label_df.set_index("vertex")
         if graph.nodes is not None:
             orphan_mask: cupy.ndarray = ~graph.nodes.value.index.isin(label_df.index)
-            orpha_nodes = nodes.data.index[orphan_mask]
+            orphan_nodes = graph.nodes.data.index[orphan_mask]
             orphan_count = orphan_mask.astype(int).sum().item()
             max_label = label_df.vertex.max()
             orphan_labels = cupy.arange(max_label + 1, max_label + 1 + orphan_count)
-            orphan_df = cudf.Series(orphan_labels, index=orpha_nodes).to_frame(
+            orphan_df = cudf.Series(orphan_labels, index=orphan_nodes).to_frame(
                 "partition"
             )
             label_df = cudf.concat([label_df, orphan_df])

--- a/metagraph_cuda/plugins/cugraph/algorithms.py
+++ b/metagraph_cuda/plugins/cugraph/algorithms.py
@@ -143,9 +143,9 @@ if has_cugraph:
         label_df = label_df.set_index("vertex")
         if graph.nodes is not None:
             orphan_mask: cupy.ndarray = ~graph.nodes.value.index.isin(label_df.index)
-            orphan_nodes = graph.nodes.value.data.index[orphan_mask]
+            orphan_nodes = graph.nodes.value.index[orphan_mask]
             orphan_count = orphan_mask.astype(int).sum().item()
-            max_label = label_df.vertex.max()
+            max_label = label_df.index.max()
             orphan_labels = cupy.arange(max_label + 1, max_label + 1 + orphan_count)
             orphan_df = cudf.Series(orphan_labels, index=orphan_nodes).to_frame(
                 "partition"

--- a/metagraph_cuda/plugins/cugraph/types.py
+++ b/metagraph_cuda/plugins/cugraph/types.py
@@ -58,11 +58,20 @@ if has_cugraph:
                 g1 = obj1.value
                 g2 = obj2.value
                 # Compare
-                assert all(
-                    g1.nodes() == g2.nodes()
-                ), f"node mismatch: {g1.nodes()} != {g2.nodes()}"
-                assert all(
-                    g1.edges() == g2.edges()
+                g1_type = type(g1.nodes())
+                g2_type = type(g2.nodes())
+                assert g1_type == g2_type, f"node type mismatch: {g1_type} != {g2_type}"
+                nodes_equal = (g1.nodes() == g2.nodes()).all()
+                if isinstance(nodes_equal, cudf.DataFrame):
+                    nodes_equal = nodes_equal.all()
+                assert nodes_equal, f"node mismatch: {g1.nodes()} != {g2.nodes()}"
+                assert len(g1.edges()) == len(
+                    g2.edges()
+                ), f"edge mismatch: {g1.edges()} != {g2.edges()}"
+                g1_edges_reindexed = g1.edges().set_index(["src", "dst"])
+                g2_edges_reindexed = g2.edges().set_index(["src", "dst"])
+                assert (
+                    g2_edges_reindexed.index.isin(g2_edges_reindexed.index).all().item()
                 ), f"edge mismatch: {g1.edges()} != {g2.edges()}"
 
     class CuGraphEdgeMap(EdgeMapWrapper, abstract=EdgeMap):
@@ -103,7 +112,7 @@ if has_cugraph:
                         weights = obj.value.view_edge_list().weights
                     else:
                         weights = obj.value.view_adj_list()[2]
-                    ret["has_negative_weights"] = any(weights < 0)
+                    ret["has_negative_weights"] = (weights < 0).any()
 
                 return ret
 
@@ -149,11 +158,20 @@ if has_cugraph:
                         g2_edge_list
                     ), f"g1 and g2 have a different number of edges"
                     # TODO the below takes an additional possibly unneeded O(n) memory
-                    assert g1_edge_list.set_index(
+                    assert len(g1.edges()) == len(
+                        g2.edges()
+                    ), f"edge mismatch: {g1.edges()} != {g2.edges()}"
+                    g1_edges_reindexed = g1_edge_list.set_index(
                         ["src", "dst", "weights"]
-                    ) == g2_edge_list.set_index(
+                    )
+                    g2_edges_reindexed = g2_edge_list.set_index(
                         ["src", "dst", "weights"]
-                    ), "g1 and g2 have different edges"
+                    )
+                    assert (
+                        g2_edges_reindexed.index.isin(g2_edges_reindexed.index)
+                        .all()
+                        .item()
+                    ), f"edge mismatch: {g1.edges()} != {g2.edges()}"
                 else:
                     assert (
                         g1.number_of_nodes() == g2.number_of_nodes()
@@ -189,156 +207,152 @@ if has_cugraph:
                 self._assert_instance(nodes, (CuDFNodeSet, CuDFNodeMap))
             super().__init__(edges, nodes)
 
-    # TODO finish this implementation once cugraph 0.15 is released on conda-forge
-    # class CuGraphBipartiteGraph(BipartiteGraphWrapper, abstract=BipartiteGraph):
-    #     def __init__(self, graph):
-    #         """
-    #         :param graph: cugraph.Graph instance s.t. cugraph.Graph.is_bipartite() returns True
-    #         """
-    #         self._assert_instance(graph, cugraph.Graph)
-    #         self._assert(graph.is_bipartite(), f'{graph} is not bipartite')
-    #         nodes = graph.sets() # TODO consider storing this as an attribute
-    #         self._assert(len(nodes) == 2, "nodes must have length of 2")
-    #         self._assert_instance(nodes[0], CuDF.Series)
-    #         self._assert_instance(nodes[1], CuDF.Series)
-    #         # O(n^2), but cheaper than converting to Python sets
-    #         common_nodes = nodes[0][nodes[0].isin(nodes[1])]
-    #         if len(common_nodes) != 0:
-    #             raise ValueError(
-    #                 f"Node IDs found in both parts of the graph: {common_nodes.values.tolist()}"
-    #             )
-    #         partition_nodes = cudf.concat([nodes[0], nodes[1]])
-    #         unclaimed_nodes_mask = ~graph.nodes().isin(partition_nodes)
-    #         if unclaimed_nodes.any():
-    #             unclaimed_nodes = graph.nodes()[unclaimed_nodes_mask].values.tolist()
-    #             raise ValueError(
-    #                 f"Node IDs found in graph, but not listed in either partition: {unclaimed_nodes}"
-    #             )
-    #         # TODO handle node weights
-    #         self.value = graph
+    class CuGraphBipartiteGraph(BipartiteGraphWrapper, abstract=BipartiteGraph):
+        def __init__(self, graph):
+            """
+            :param graph: cugraph.Graph instance s.t. cugraph.Graph.is_bipartite() returns True
+            """
+            self._assert_instance(graph, cugraph.Graph)
+            self._assert(graph.is_bipartite(), f"{graph} is not bipartite")
+            nodes = graph.sets()  # TODO consider storing this as an attribute
+            self._assert(len(nodes) == 2, "nodes must have length of 2")
+            self._assert_instance(nodes[0], cudf.Series)
+            self._assert_instance(nodes[1], cudf.Series)
+            # O(n^2), but cheaper than converting to Python sets
+            common_nodes = nodes[0][nodes[0].isin(nodes[1])]
+            if len(common_nodes) != 0:
+                raise ValueError(
+                    f"Node IDs found in both parts of the graph: {common_nodes.values.tolist()}"
+                )
+            partition_nodes = cudf.concat([nodes[0], nodes[1]])
+            unclaimed_nodes_mask = ~graph.nodes().isin(partition_nodes)
+            if unclaimed_nodes_mask.any():
+                unclaimed_nodes = graph.nodes()[unclaimed_nodes_mask].values.tolist()
+                raise ValueError(
+                    f"Node IDs found in graph, but not listed in either partition: {unclaimed_nodes}"
+                )
+            # TODO handle node weights
+            self.value = graph
 
-    #     class TypeMixin:
-    #         @classmethod
-    #         def _compute_abstract_properties(
-    #             cls, obj, props: Set[str], known_props: Dict[str, Any]
-    #         ) -> Dict[str, Any]:
-    #             ret = known_props.copy()
+        class TypeMixin:
+            @classmethod
+            def _compute_abstract_properties(
+                cls, obj, props: Set[str], known_props: Dict[str, Any]
+            ) -> Dict[str, Any]:
+                ret = known_props.copy()
 
-    #             if {"edge_type", "edge_dtype", "edge_has_negative_weights"} & (
-    #                 props - ret.keys()
-    #             ):
-    #                 if obj.value.edgelist:
-    #                     edgelist = obj.value.view_edge_list()
-    #                     weights = (
-    #                         edgelist.weights if "weights" in edgelist.columns else None
-    #                     )
-    #                 else:
-    #                     weights = obj.value.view_adj_list()[2]
+                if {"edge_type", "edge_dtype", "edge_has_negative_weights"} & (
+                    props - ret.keys()
+                ):
+                    if obj.value.edgelist:
+                        edgelist = obj.value.view_edge_list()
+                        weights = (
+                            edgelist.weights if "weights" in edgelist.columns else None
+                        )
+                    else:
+                        weights = obj.value.view_adj_list()[2]
 
-    #             # fast properties
-    #             for prop in {
-    #                     "is_directed",
-    #                     "edge_type",
-    #                     "edge_dtype",
-    #             } - ret.keys():
-    #                 if prop == "is_directed":
-    #                     ret[prop] = obj.value.is_directed()
-    #                 elif prop == "edge_type":
-    #                     ret[prop] = "set" if weights is None else "map"
-    #                 elif prop == "edge_dtype":
-    #                     ret[prop] = dtypes.dtypes_simplified[weights.dtype]
+                # fast properties
+                for prop in {"is_directed", "edge_type", "edge_dtype",} - ret.keys():
+                    if prop == "is_directed":
+                        ret[prop] = obj.value.is_directed()
+                    elif prop == "edge_type":
+                        ret[prop] = "set" if weights is None else "map"
+                    elif prop == "edge_dtype":
+                        ret[prop] = dtypes.dtypes_simplified[weights.dtype]
 
-    #             # slow properties, only compute if asked
-    #             slow_props = props - ret.keys()
-    #             if {"node0_dtype", "node1_dtype"} & slow_props:
-    #                 nodes = obj.value.sets()
-    #                 if prop == "node0_dtype":
-    #                     ret[prop] = dtypes.dtypes_simplified[obj.nodes[0].dtype]
-    #                 elif prop == "node1_dtype":
-    #                     ret[prop] = dtypes.dtypes_simplified[obj.nodes[1].dtype]
-    #             slow_props = slow_props - ret.keys()
-    #             if {"node0_type", "node1_type", "edge_has_negative_weights"} & slow_props:
-    #                 for prop in slow_props:
-    #                     if prop == "node0_type":
-    #                         # TODO properly handle when node weights are supported
-    #                         ret[prop] = "set"
-    #                     elif prop == "node1_type":
-    #                         # TODO properly handle when node weights are supported
-    #                         ret[prop] = "set"
-    #                     elif prop == "edge_has_negative_weights":
-    #                         ret[prop] = weights.lt(0).any()
+                # slow properties, only compute if asked
+                slow_props = props - ret.keys()
+                if {"node0_dtype", "node1_dtype"} & slow_props:
+                    nodes = obj.value.sets()
+                    if prop == "node0_dtype":
+                        ret[prop] = dtypes.dtypes_simplified[obj.nodes[0].dtype]
+                    elif prop == "node1_dtype":
+                        ret[prop] = dtypes.dtypes_simplified[obj.nodes[1].dtype]
+                slow_props = slow_props - ret.keys()
+                if {
+                    "node0_type",
+                    "node1_type",
+                    "edge_has_negative_weights",
+                } & slow_props:
+                    for prop in slow_props:
+                        if prop == "node0_type":
+                            # TODO properly handle when node weights are supported
+                            ret[prop] = "set"
+                        elif prop == "node1_type":
+                            # TODO properly handle when node weights are supported
+                            ret[prop] = "set"
+                        elif prop == "edge_has_negative_weights":
+                            ret[prop] = weights.lt(0).any()
 
-    #             return ret
+                return ret
 
-    #         @classmethod
-    #         def assert_equal(
-    #             cls,
-    #             obj1,
-    #             obj2,
-    #             aprops1,
-    #             aprops2,
-    #             cprops1,
-    #             cprops2,
-    #             *,
-    #             rel_tol=1e-9,
-    #             abs_tol=0.0,
-    #         ):
-    #             assert aprops1 == aprops2, f"property mismatch: {aprops1} != {aprops2}"
-    #             g1 = obj1.value
-    #             g2 = obj2.value
-    #             canonicalize_nodes = lambda series: series.set_index(series)
-    #             obj1_nodes = [canonicalize_nodes(nodes) for nodes in obj1.value.sets()]
-    #             obj2_nodes = [canonicalize_nodes(nodes) for nodes in obj2.value.sets()]
-    #             # Compare
-    #             assert len(obj1_nodes[0]) == len(
-    #                 obj2_nodes[0]
-    #             ), f"{len(obj1_nodes[0])} == {len(obj2_nodes[0])}"
-    #             assert len(obj1_nodes[1]) == len(
-    #                 obj2_nodes[1]
-    #             ), f"{len(obj1_nodes[1])} == {len(obj2_nodes[1])}"
-    #             canonicalize_nodes = lambda series: series.set_index(series)
-    #             obj1_nodes = [canonicalize_nodes(nodes) for nodes in obj1_nodes]
-    #             obj2_nodes = [canonicalize_nodes(nodes) for nodes in obj2_nodes]
-    #             assert all(
-    #                 obj1_nodes[0] == obj2_nodes[0]
-    #             ), f"{obj1_nodes[0]} != {obj2_nodes[0]}"
-    #             assert all(
-    #                 obj1_nodes[1] == obj2_nodes[1]
-    #             ), f"{obj1_nodes[1]} != {obj2_nodes[1]}"
-    #             assert (
-    #                 g1.number_of_edges() == g2.number_of_edges()
-    #             ), f"{g1.number_of_edges()} != {g2.number_of_edges()}"
-    #             if g1.edgelist:
-    #                 g1_edge_list = g1.view_edge_list()
-    #                 g2_edge_list = g2.view_edge_list()
-    #                 assert len(g1_edge_list) == len(
-    #                     g2_edge_list
-    #                 ), f"g1 and g2 have a different number of edges"
-    #                 assert len(g1_edge_list.columns) == len(
-    #                     g2_edge_list.columns
-    #                 ), "one of g1 or g2 is weighted while the other is not"
-    #                 columns = g1_edge_list.columns
-    #                 # TODO the below takes an additional possibly unneeded O(n) memory
-    #                 assert g1_edge_list.set_index(columns) == g2_edge_list.set_index(
-    #                     columns
-    #                 ), "g1 and g2 have different edges"
+            @classmethod
+            def assert_equal(
+                cls,
+                obj1,
+                obj2,
+                aprops1,
+                aprops2,
+                cprops1,
+                cprops2,
+                *,
+                rel_tol=1e-9,
+                abs_tol=0.0,
+            ):
+                assert aprops1 == aprops2, f"property mismatch: {aprops1} != {aprops2}"
+                g1 = obj1.value
+                g2 = obj2.value
+                canonicalize_nodes = lambda series: series.set_index(series)
+                obj1_nodes = [canonicalize_nodes(nodes) for nodes in obj1.value.sets()]
+                obj2_nodes = [canonicalize_nodes(nodes) for nodes in obj2.value.sets()]
+                # Compare
+                assert len(obj1_nodes[0]) == len(
+                    obj2_nodes[0]
+                ), f"{len(obj1_nodes[0])} == {len(obj2_nodes[0])}"
+                assert len(obj1_nodes[1]) == len(
+                    obj2_nodes[1]
+                ), f"{len(obj1_nodes[1])} == {len(obj2_nodes[1])}"
+                assert all(
+                    obj1_nodes[0] == obj2_nodes[0]
+                ), f"{obj1_nodes[0]} != {obj2_nodes[0]}"
+                assert all(
+                    obj1_nodes[1] == obj2_nodes[1]
+                ), f"{obj1_nodes[1]} != {obj2_nodes[1]}"
+                assert (
+                    g1.number_of_edges() == g2.number_of_edges()
+                ), f"{g1.number_of_edges()} != {g2.number_of_edges()}"
+                if g1.edgelist:
+                    g1_edge_list = g1.view_edge_list()
+                    g2_edge_list = g2.view_edge_list()
+                    assert len(g1_edge_list) == len(
+                        g2_edge_list
+                    ), f"g1 and g2 have a different number of edges"
+                    assert len(g1_edge_list.columns) == len(
+                        g2_edge_list.columns
+                    ), "one of g1 or g2 is weighted while the other is not"
+                    columns = g1_edge_list.columns
+                    # TODO the below takes an additional possibly unneeded O(n) memory
+                    assert g1_edge_list.set_index(columns) == g2_edge_list.set_index(
+                        columns
+                    ), "g1 and g2 have different edges"
 
-    #             else:
-    #                 for i, g1_series in enumerate(g1.view_adj_list()):
-    #                     g2_series = g1.view_adj_list()[i]
-    #                     assert (g1_series is None) == (
-    #                         g2_series is None
-    #                     ), "one of g1 or g2 is weighted while the other is not"
-    #                     if g1_series is not None:
-    #                         if np.issubdtype(g1_series.dtype.type, np.float):
-    #                             assert cupy.isclose(g1_series == g2_series)
-    #                         else:
-    #                             assert all(
-    #                                 g1_series == g2_series
-    #                             ), "g1 and g2 have different edges"
+                else:
+                    for i, g1_series in enumerate(g1.view_adj_list()):
+                        g2_series = g1.view_adj_list()[i]
+                        assert (g1_series is None) == (
+                            g2_series is None
+                        ), "one of g1 or g2 is weighted while the other is not"
+                        if g1_series is not None:
+                            if np.issubdtype(g1_series.dtype.type, np.float):
+                                assert cupy.isclose(g1_series == g2_series)
+                            else:
+                                assert all(
+                                    g1_series == g2_series
+                                ), "g1 and g2 have different edges"
 
-    #             if aprops1.get("node0_type") == "map":
-    #                 pass  # TODO handle this when node weights are supported
+                if aprops1.get("node0_type") == "map":
+                    pass  # TODO handle this when node weights are supported
 
-    #             if aprops1.get("node1_type") == "map":
-    #                 pass  # TODO handle this when node weights are supported
+                if aprops1.get("node1_type") == "map":
+                    pass  # TODO handle this when node weights are supported

--- a/metagraph_cuda/tests/translators/test_to_cugraph_translators.py
+++ b/metagraph_cuda/tests/translators/test_to_cugraph_translators.py
@@ -10,17 +10,16 @@ from metagraph_cuda.plugins.cugraph.types import CuGraph, CuGraphEdgeSet, CuGrap
 
 def test_scipy_edge_set_to_cugraph_edge_set():
     """
-          +-+
- ------>  |1|
- |        +-+
- | 
- |         |
- |         v
+              +-+
+     ------>  |1|
+     |        +-+
+     |
+     |         |
+     |         v
 
-+-+  <--  +-+       +-+
-|0|       |2|  <--  |3|
-+-+  -->  +-+       +-+
-"""
+    +-+  <--  +-+       +-+
+    |0|       |2|  <--  |3|
+    +-+  -->  +-+       +-+"""
     dpr = mg.resolver
     scipy_sparse_matrix = ss.csr_matrix(
         np.array([[0, 1, 1, 0], [0, 0, 1, 0], [1, 0, 0, 0], [0, 0, 1, 0],])
@@ -43,19 +42,18 @@ def test_scipy_edge_set_to_cugraph_edge_set():
 
 def test_scipy_edge_map_to_cugraph_edge_map():
     """
-          +-+
- ----9->  |1|
- |        +-+
- | 
- |         |
- |         6
- |         |
- |         v
+              +-+
+     ----9->  |1|
+     |        +-+
+     |
+     |         |
+     |         6
+     |         |
+     |         v
 
-+-+  <-7-  +-+        +-+
-|0|        |2|  <-5-  |3|
-+-+  -8->  +-+        +-+
-"""
+    +-+  <-7-  +-+        +-+
+    |0|        |2|  <-5-  |3|
+    +-+  -8->  +-+        +-+"""
     dpr = mg.resolver
     scipy_sparse_matrix = ss.csr_matrix(
         np.array([[0, 9, 8, 0], [0, 0, 6, 0], [7, 0, 0, 0], [0, 0, 5, 0],])
@@ -64,7 +62,7 @@ def test_scipy_edge_map_to_cugraph_edge_map():
 
     sources = [0, 0, 1, 2, 3]
     destinations = [1, 2, 2, 0, 2]
-    weights = [9, 8, 7, 6, 5]
+    weights = [9, 8, 6, 7, 5]
     cdf = cudf.DataFrame(
         {"source": sources, "destination": destinations, "weights": weights}
     )
@@ -81,17 +79,16 @@ def test_scipy_edge_map_to_cugraph_edge_map():
 
 def test_unweighted_directed_networkx_to_cugraph():
     """
-          +-+
- ------>  |1|
- |        +-+
- | 
- |         |
- |         v
+              +-+
+     ------>  |1|
+     |        +-+
+     |
+     |         |
+     |         v
 
-+-+  <--  +-+       +-+
-|0|       |2|  <--  |3|
-+-+  -->  +-+       +-+
-"""
+    +-+  <--  +-+       +-+
+    |0|       |2|  <--  |3|
+    +-+  -->  +-+       +-+"""
     dpr = mg.resolver
     networkx_graph_data = [
         (0, 1),
@@ -117,19 +114,18 @@ def test_unweighted_directed_networkx_to_cugraph():
 
 def test_weighted_directed_networkx_to_cugraph():
     """
-          +-+
- ----9->  |1|
- |        +-+
- | 
- |         |
- |         6
- |         |
- |         v
+              +-+
+     ----9->  |1|
+     |        +-+
+     |
+     |         |
+     |         6
+     |         |
+     |         v
 
-+-+  <-7-  +-+        +-+
-|0|        |2|  <-5-  |3|
-+-+  -8->  +-+        +-+
-"""
+    +-+  <-7-  +-+        +-+
+    |0|        |2|  <-5-  |3|
+    +-+  -8->  +-+        +-+"""
     dpr = mg.resolver
     networkx_graph_data = [
         (0, 1, 9),
@@ -162,17 +158,16 @@ def test_weighted_directed_networkx_to_cugraph():
 
 def test_pandas_edge_set_to_cugraph_edge_set():
     """
-          +-+
- ------>  |1|
- |        +-+
- | 
- |         |
- |         v
+              +-+
+     ------>  |1|
+     |        +-+
+     |
+     |         |
+     |         v
 
-+-+  <--  +-+       +-+
-|0|       |2|  <--  |3|
-+-+  -->  +-+       +-+
-"""
+    +-+  <--  +-+       +-+
+    |0|       |2|  <--  |3|
+    +-+  -->  +-+       +-+"""
     dpr = mg.resolver
     pdf = pd.DataFrame({"src": (0, 0, 2, 1, 3), "dst": (1, 2, 0, 2, 2),})
     x = dpr.wrappers.EdgeSet.PandasEdgeSet(
@@ -192,19 +187,18 @@ def test_pandas_edge_set_to_cugraph_edge_set():
 
 def test_pandas_edge_map_to_cugraph_edge_map():
     """
-          +-+
- ----9->  |1|
- |        +-+
- | 
- |         |
- |         6
- |         |
- |         v
+              +-+
+     ----9->  |1|
+     |        +-+
+     |
+     |         |
+     |         6
+     |         |
+     |         v
 
-+-+  <-7-  +-+        +-+
-|0|        |2|  <-5-  |3|
-+-+  -8->  +-+        +-+
-"""
+    +-+  <-7-  +-+        +-+
+    |0|        |2|  <-5-  |3|
+    +-+  -8->  +-+        +-+"""
     dpr = mg.resolver
     pdf = pd.DataFrame(
         {"src": (0, 0, 2, 1, 3), "dst": (1, 2, 0, 2, 2), "w": (9, 8, 7, 6, 5),}
@@ -232,17 +226,16 @@ def test_pandas_edge_map_to_cugraph_edge_map():
 
 def test_scipy_graph_to_cugraph_graph():
     """
-          +-+       +-+
- ------>  |1|       |4|
- |        +-+       +-+
- | 
- |         |
- |         v
+              +-+       +-+
+     ------>  |1|       |4|
+     |        +-+       +-+
+     |
+     |         |
+     |         v
 
-+-+  <--  +-+       +-+
-|0|       |2|  <--  |3|
-+-+  -->  +-+       +-+
-"""
+    +-+  <--  +-+       +-+
+    |0|       |2|  <--  |3|
+    +-+  -->  +-+       +-+"""
     dpr = mg.resolver
     scipy_sparse_matrix = ss.csr_matrix(
         np.array([[0, 1, 1, 0], [0, 0, 1, 0], [1, 0, 0, 0], [0, 0, 1, 0],])


### PR DESCRIPTION
This commit implements bipartite graphs for the cugraph plugin.

This commit also updates to the `environment.yml` to use `cugraph` 0.15 and `dask-cudf` and `dask-cuda`. The latter two are depended on by `cugraph` 0.15.
