### PR TITLE
Refactor metagraph-cuda to pass roundtripper tests

### DIFF
--- a/metagraph_cuda/plugins/cudf/algorithms.py
+++ b/metagraph_cuda/plugins/cudf/algorithms.py
@@ -21,9 +21,9 @@ if has_cudf:
     def cudf_nodemap_sort(
         x: CuDFNodeMap, ascending: bool, limit: mg.Optional[int]
     ) -> CuDFVector:
-        positions_of_sorted_values = (
-            x.value[x.value_label].argsort(ascending=ascending).values
-        )
+        positions_of_sorted_values = x.value.values.argsort()
+        if not ascending:
+            positions_of_sorted_values = positions_of_sorted_values[::-1]
         if limit is not None:
             positions_of_sorted_values = positions_of_sorted_values[0:limit]
         data = x.value.iloc[positions_of_sorted_values].index.to_series(
@@ -34,19 +34,18 @@ if has_cudf:
     @concrete_algorithm("util.nodemap.select")
     def cudf_nodemap_select(x: CuDFNodeMap, nodes: CuDFNodeSet) -> CuDFNodeMap:
         data = x.value.loc[nodes.value].copy()
-        return CuDFNodeMap(data, x.value_label)
+        return CuDFNodeMap(data)
 
     @concrete_algorithm("util.nodemap.filter")
     def cudf_nodemap_filter(x: CuDFNodeMap, func: Callable[[Any], bool]) -> CuDFNodeSet:
-        keep_mask = x.value[x.value_label].applymap(func).values
+        keep_mask = x.value.applymap(func).values
         nodes = x.value.iloc[keep_mask].index.to_series()
         return CuDFNodeSet(nodes)
 
     @concrete_algorithm("util.nodemap.apply")
     def cudf_nodemap_apply(x: CuDFNodeMap, func: Callable[[Any], Any]) -> CuDFNodeMap:
-        new_column_name = "applied"
-        data = x.value[x.value_label].applymap(func).to_frame(new_column_name)
-        return CuDFNodeMap(data, new_column_name)
+        data = x.value.applymap(func).set_index(x.value.index)
+        return CuDFNodeMap(data)
 
     # TODO cupy.ufunc's reduce not supported https://docs.cupy.dev/en/stable/reference/ufunc.html#universal-functions-ufunc
     # @concrete_algorithm("util.nodemap.reduce")

--- a/metagraph_cuda/plugins/cudf/translators.py
+++ b/metagraph_cuda/plugins/cudf/translators.py
@@ -174,7 +174,6 @@ if has_cudf and has_scipy:
             rc_pairs = filter(lambda pair: pair[0] <= pair[1], rc_pairs)
         rc_pairs = list(rc_pairs)
         df = cudf.DataFrame(rc_pairs, columns=["source", "target"])
-        print(f"props {repr(props)}")
         return CuDFEdgeSet(df, is_directed=is_directed)
 
     @translator

--- a/metagraph_cuda/plugins/cudf/translators.py
+++ b/metagraph_cuda/plugins/cudf/translators.py
@@ -170,7 +170,6 @@ if has_cudf and has_scipy:
         row_ids = map(get_node_from_pos, coo_matrix.row)
         column_ids = map(get_node_from_pos, coo_matrix.col)
         rc_pairs = zip(row_ids, column_ids)
-        rc_pairs = list(rc_pairs)  # TODO remove this
         if not is_directed:
             rc_pairs = filter(lambda pair: pair[0] <= pair[1], rc_pairs)
         rc_pairs = list(rc_pairs)

--- a/metagraph_cuda/plugins/cudf/translators.py
+++ b/metagraph_cuda/plugins/cudf/translators.py
@@ -2,8 +2,12 @@ from metagraph import translator, dtypes
 from metagraph.plugins import has_pandas, has_scipy
 import numpy as np
 from .. import has_cudf
-from metagraph.plugins.numpy.types import NumpyNodeSet, NumpyNodeMap, NumpyVector
-from metagraph.plugins.python.types import PythonNodeSet, PythonNodeMap, dtype_casting
+from metagraph.plugins.numpy.types import NumpyNodeSet, NumpyNodeMap, NumpyVectorType
+from metagraph.plugins.python.types import (
+    PythonNodeSetType,
+    PythonNodeMapType,
+    dtype_casting,
+)
 
 if has_cudf:
     import cudf
@@ -28,110 +32,61 @@ if has_cudf:
     @translator
     def translate_nodes_cudfnodemap2pythonnodemap(
         x: CuDFNodeMap, **props
-    ) -> PythonNodeMap:
-        cast = dtype_casting[dtypes.dtypes_simplified[x.value[x.value_label].dtype]]
-        data = {
-            i.item(): cast(x.value.loc[i.item()].loc[x.value_label])
-            for i in x.value.index.values
-        }
-        return PythonNodeMap(data)
+    ) -> PythonNodeMapType:
+        cast = dtype_casting[dtypes.dtypes_simplified[x.value.dtype]]
+        data = {i.item(): cast(x.value.loc[i.item()]) for i in x.value.index.values}
+        return data
 
     @translator
     def translate_nodes_pythonnodemap2cudfnodemap(
-        x: PythonNodeMap, **props
+        x: PythonNodeMapType, **props
     ) -> CuDFNodeMap:
-        keys, values = zip(*x.value.items())
+        keys, values = zip(*x.items())
         # TODO consider special casing the situation when all the keys form a compact range
-        data = cudf.DataFrame({"value": values}, index=keys)
-        return CuDFNodeMap(data, "value")
+        data = cudf.Series(values, index=keys)
+        return CuDFNodeMap(data)
 
     @translator
     def translate_nodes_cudfnodeset2pythonnodeset(
         x: CuDFNodeSet, **props
-    ) -> PythonNodeSet:
-        return PythonNodeSet(set(x.value.index.to_pandas()))
+    ) -> PythonNodeSetType:
+        return set(x.value.index.to_pandas())
 
     @translator
     def translate_nodes_pythonnodeset2cudfnodeset(
-        x: PythonNodeSet, **props
+        x: PythonNodeSetType, **props
     ) -> CuDFNodeSet:
-        return CuDFNodeSet(cudf.Series(x.value))
+        return CuDFNodeSet(cudf.Series(x))
 
     @translator
-    def translate_nodes_numpyvector2cudfvector(x: NumpyVector, **props) -> CuDFVector:
-        if x.mask is not None:
-            data = x.value[x.mask]
-            series = cudf.Series(data, index=np.flatnonzero(x.mask))
-        else:
-            data = x.value
-            series = cudf.Series(data)
+    def translate_nodes_numpyvector2cudfvector(
+        x: NumpyVectorType, **props
+    ) -> CuDFVector:
+        data = x.value
+        series = cudf.Series(data)
         return CuDFVector(series)
 
     @translator
-    def translate_vector_cudfvector2numpyvector(x: CuDFVector, **props) -> NumpyVector:
-        is_dense = CuDFVector.Type.compute_abstract_properties(x, {"is_dense"})[
-            "is_dense"
-        ]
-        if is_dense:
-            np_vector = cupy.asnumpy(x.value.sort_index().values)
-            mask = None
-        else:
-            series = x.value.sort_index()
-            positions = series.index.to_array()
-            np_vector = np.empty(len(x), dtype=series.dtype)
-            np_vector[positions] = cupy.asnumpy(series.values)
-            mask = np.zeros(len(x), dtype=bool)
-            mask[positions] = True
-        return NumpyVector(np_vector, mask=mask)
+    def translate_vector_cudfvector2numpyvector(
+        x: CuDFVector, **props
+    ) -> NumpyVectorType:
+        np_vector = cupy.asnumpy(x.values)
+        return np_vector
 
     @translator
     def translate_nodes_numpynodemap2cudfnodemap(
         x: NumpyNodeMap, **props
     ) -> CuDFNodeMap:
-        if x.mask is not None:
-            keys = np.flatnonzero(x.value)
-            np_values = x.value[mask]
-            # TODO make CuDFNodeMap store a Series instead of DataFrame to avoid making 2 copies here
-            df = cudf.Series(np_values, index=keys).to_frame("value")
-        elif x.pos2id is not None:
-            # TODO make CuDFNodeMap store a Series instead of DataFrame to avoid making 2 copies here
-            df = cudf.DataFrame({"value": x.value}, index=x.pos2id)
-        else:
-            df = cudf.DataFrame({"value": x.value})
-        return CuDFNodeMap(df, "value")
+        series = cudf.Series(x.value).set_index(x.nodes)
+        return CuDFNodeMap(series)
 
     @translator
     def translate_nodes_cudfnodemap2numpynodemap(
         x: CuDFNodeMap, **props
     ) -> NumpyNodeMap:
-        if isinstance(x.value.index, cudf.core.index.RangeIndex):
-            x_index_min = x.value.index.start
-            x_index_max = x.value.index.stop - 1
-        else:
-            x_index_min = x.value.index.min()
-            x_index_max = x.value.index.max()
-        x_density = (x_index_max + 1 - x_index_min) / (x_index_max + 1)
-        if x_density == 1.0:
-            data = np.empty(len(x.value), dtype=x.value[x.value_label].dtype)
-            data[cupy.asnumpy(x.value.index.values)] = cupy.asnumpy(
-                x.value[x.value_label].values
-            )
-            mask = None
-            node_ids = None
-        elif x_density > 0.5:  # TODO consider moving this threshold out to a global
-            data = np.empty(x_index_max + 1, dtype=x.value[x.value_label].dtype)
-            position_selector = cupy.asnumpy(x.value.index.values)
-            data[position_selector] = cupy.asnumpy(x.value[x.value_label].values)
-            mask = np.zeros(x_index_max + 1, dtype=bool)
-            mask[position_selector] = True
-            node_ids = None
-        else:
-            # O(n log n) sort, but n is small since not dense
-            df_index_sorted = x.value.sort_index()
-            data = cupy.asnumpy(df_index_sorted[x.value_label].values)
-            node_ids = dict(map(reversed, enumerate(df_index_sorted.index.values_host)))
-            mask = None
-        return NumpyNodeMap(data, mask=mask, node_ids=node_ids)
+        return NumpyNodeMap(
+            cupy.asnumpy(x.value.values), nodes=cupy.asnumpy(x.value.index.to_array())
+        )
 
     @translator
     def translate_nodes_numpynodeset2cudfnodeset(

--- a/metagraph_cuda/plugins/cudf/translators.py
+++ b/metagraph_cuda/plugins/cudf/translators.py
@@ -212,15 +212,10 @@ if has_cudf and has_scipy:
             self_loop_mask = cdf[x.src_label] == cdf[x.dst_label]
             self_loop_df = cdf[self_loop_mask]
             no_self_loop_df = cdf[~self_loop_mask]
-            cdf = cudf.concat(
-                [
-                    no_self_loop_df,
-                    no_self_loop_df.rename(
-                        columns={x.src_label: x.dst_label, x.dst_label: x.src_label}
-                    ),
-                    self_loop_df,
-                ]
+            repeat_df = no_self_loop_df.rename(
+                columns={x.src_label: x.dst_label, x.dst_label: x.src_label}
             )
+            cdf = cudf.concat([no_self_loop_df, repeat_df, self_loop_df,])
         source_positions = list(map(get_id_pos, cdf[x.src_label].values_host))
         target_positions = list(map(get_id_pos, cdf[x.dst_label].values_host))
         target_positions = np.array(target_positions)
@@ -246,15 +241,10 @@ if has_cudf and has_scipy:
             self_loop_mask = cdf[x.src_label] == cdf[x.dst_label]
             self_loop_df = cdf[self_loop_mask]
             no_self_loop_df = cdf[~self_loop_mask]
-            cdf = cudf.concat(
-                [
-                    no_self_loop_df,
-                    no_self_loop_df.rename(
-                        columns={x.src_label: x.dst_label, x.dst_label: x.src_label}
-                    ),
-                    self_loop_df,
-                ]
+            repeat_df = no_self_loop_df.rename(
+                columns={x.src_label: x.dst_label, x.dst_label: x.src_label}
             )
+            cdf = cudf.concat([no_self_loop_df, repeat_df, self_loop_df,])
         source_positions = list(map(get_id_pos, cdf[x.src_label].values_host))
         target_positions = list(map(get_id_pos, cdf[x.dst_label].values_host))
         weights = cupy.asnumpy(cdf[x.weight_label].values)

--- a/metagraph_cuda/plugins/cudf/types.py
+++ b/metagraph_cuda/plugins/cudf/types.py
@@ -70,18 +70,7 @@ if has_cudf:
                 ret = known_props.copy()
 
                 # fast properties
-                for prop in {"is_dense", "dtype"} - ret.keys():
-                    if prop == "is_dense":
-                        if isinstance(obj.value.index, cudf.core.index.RangeIndex):
-                            ret[prop] = (
-                                obj.value.index.start == 0
-                                and obj.value.index.stop == len(obj.value)
-                            )
-                        else:
-                            ret[prop] = (
-                                obj.value.index.min() == 0
-                                and obj.value.index.max() == len(obj.value) - 1
-                            )
+                for prop in {"dtype"} - ret.keys():
                     if prop == "dtype":
                         ret[prop] = dtypes.dtypes_simplified[obj.value.dtype]
 
@@ -279,7 +268,10 @@ if has_cudf:
                 # slow properties, only compute if asked
                 for prop in props - ret.keys():
                     if prop == "has_negative_weights":
-                        ret[prop] = obj.value[obj.weight_label].lt(0).any()
+                        if ret["dtype"] == "bool":
+                            ret[prop] = None
+                        else:
+                            ret[prop] = obj.value[obj.weight_label].lt(0).any()
 
                 return ret
 

--- a/metagraph_cuda/plugins/cudf/types.py
+++ b/metagraph_cuda/plugins/cudf/types.py
@@ -99,7 +99,7 @@ if has_cudf:
 
     class CuDFNodeMap(NodeMapWrapper, abstract=NodeMap):
         """
-        CuDFNodeMap stores data in a cudf.Series where the index corresponds go the node ids
+        CuDFNodeMap stores data in a cudf.Series where the index corresponds to the node ids
         and the entries correspond to the mapped values.
         """
 

--- a/metagraph_cuda/plugins/cugraph/algorithms.py
+++ b/metagraph_cuda/plugins/cugraph/algorithms.py
@@ -10,24 +10,6 @@ if has_cugraph:
     from .types import CuGraph, CuGraphBipartiteGraph, CuGraphEdgeSet, CuGraphEdgeMap
     from ..cudf.types import CuDFVector, CuDFNodeSet, CuDFNodeMap
 
-    @concrete_algorithm("util.edgemap.from_edgeset")
-    def cugraph_edgemap_from_edgeset(
-        edgeset: CuGraphEdgeSet, default_value: Any,
-    ) -> CuGraphEdgeMap:
-        g = cugraph.DiGraph() if edgeset.value.is_directed() else cugraph.Graph()
-        if edgeset.value.edgelist is not None:
-            # TODO avoid copying the 'src' and 'dst' columns twice
-            gdf = edgeset.value.view_edge_list().copy()
-            gdf["weight"] = cupy.full(len(gdf), default_value)
-            g.from_cudf_edgelist(
-                gdf, source="src", destination="dst", edge_attr="weight"
-            )
-        else:
-            offset_col, index_col, _ = g.view_adj_list()
-            value_col = cudf.Series(cupy.full(len(offset_col), default_value))
-            g.from_cudf_adjlist(offset_col, index_col, value_col)
-        return CuGraphEdgeMap(g)
-
     # TODO only works for unweighted graphs ; make this only work for unweighted graphs
     # @concrete_algorithm("centrality.betweenness")
     # def cugraph_betweenness_centrality(
@@ -35,36 +17,38 @@ if has_cugraph:
     #         nodes: mg.Optional[CuDFNodeSet], # TODO verify this is correct
     #         normalize: bool,
     # ) -> CuDFNodeMap:
-    #     node_to_score_df = cugraph.betweenness_centrality(graph.edges.value, k=None if nodes is None else nodes.value.tolist(), normalized=False) # TODO use 'weights' param
+    #     node_to_score_df = cugraph.betweenness_centrality(graph.value, k=None if nodes is None else nodes.value.tolist(), normalized=False) # TODO use 'weights' param
     #     node_to_score_df = node_to_score_df.set_index("vertex")
     #     return CuDFNodeMap(node_to_score_df, "betweenness_centrality",)
 
     @concrete_algorithm("clustering.connected_components")
     def connected_components(graph: CuGraph) -> CuDFNodeMap:
-        df = cugraph.weakly_connected_components(graph.edges.value)
-        df = df.set_index("vertices")
-        return CuDFNodeMap(df, "labels")
+        series = cugraph.weakly_connected_components(graph.value).set_index("vertices")[
+            "labels"
+        ]
+        return CuDFNodeMap(series)
 
     @concrete_algorithm("clustering.strongly_connected_components")
     def strongly_connected_components(graph: CuGraph) -> CuDFNodeMap:
-        df = cugraph.strongly_connected_components(graph.edges.value)
-        df = df.set_index("vertices")
-        return CuDFNodeMap(df, "labels")
+        series = cugraph.strongly_connected_components(graph.value).set_index(
+            "vertices"
+        )["labels"]
+        return CuDFNodeMap(series)
 
     @concrete_algorithm("centrality.pagerank")
     def cugraph_pagerank(
         graph: CuGraph, damping: float, maxiter: int, tolerance: float,
     ) -> CuDFNodeMap:
         pagerank = cugraph.pagerank(
-            graph.edges.value, alpha=damping, max_iter=maxiter, tol=tolerance
-        ).set_index("vertex")
-        return CuDFNodeMap(pagerank, "pagerank")
+            graph.value, alpha=damping, max_iter=maxiter, tol=tolerance
+        ).set_index("vertex")["pagerank"]
+        return CuDFNodeMap(pagerank)
 
     @concrete_algorithm("traversal.bfs_iter")
     def breadth_first_search(
         graph: CuGraph, source_node: NodeID, depth_limit: int
     ) -> CuDFVector:
-        bfs_df = cugraph.bfs(graph.edges.value, source_node)
+        bfs_df = cugraph.bfs(graph.value, source_node)
         bfs_df = bfs_df[bfs_df.predecessor.isin(bfs_df.vertex) | (bfs_df.distance == 0)]
         bfs_ordered_vertices = bfs_df.sort_values("distance").vertex.reset_index(
             drop=True
@@ -73,7 +57,7 @@ if has_cugraph:
 
     @concrete_algorithm("cluster.triangle_count")
     def cugraph_triangle_count(graph: CuGraph) -> int:
-        return cugraph.triangles(graph.edges.value) // 3
+        return cugraph.triangles(graph.value) // 3
 
     # TODO cupy.ufunc's reduce not supported https://docs.cupy.dev/en/stable/reference/ufunc.html#universal-functions-ufunc
     # @concrete_algorithm("util.graph.aggregate_edges")
@@ -90,11 +74,9 @@ if has_cugraph:
     def cugraph_graph_filter_edges(
         graph: CuGraph, func: Callable[[Any], bool]
     ) -> CuGraph:
-        new_g = (
-            cugraph.DiGraph() if graph.edges.value.is_directed() else cugraph.Graph()
-        )
+        new_g = cugraph.DiGraph() if graph.value.is_directed() else cugraph.Graph()
         # TODO do something more optimal when there's an adjlist and no edgelist
-        df = graph.edges.value.view_edge_list()
+        df = graph.value.view_edge_list()
         keep_mask = df["weights"].applymap(func).values
         # TODO reset_index is workaround for https://github.com/rapidsai/cugraph/issues/1080
         keep_df = df.iloc[keep_mask].reset_index(drop=True)
@@ -105,26 +87,44 @@ if has_cugraph:
         graph_nodes = cudf.concat([df["src"], df["dst"]]).unique()
         new_g_nodes = cudf.concat([keep_df["src"], keep_df["dst"]]).unique()
         any_nodes_lost = (~graph_nodes.isin(new_g_nodes)).any()
-        if any_nodes_lost:
-            nodes = CuDFNodeSet(graph_nodes)
-        elif graph.nodes is None:
-            nodes = None
+        return CuGraph(new_g, graph_nodes)
+
+    def _assign_uniform_weight(
+        input_graph: cugraph.Graph, default_value: Any
+    ) -> cugraph.Graph:
+        g = cugraph.DiGraph() if input_graph.is_directed() else cugraph.Graph()
+        if input_graph.edgelist is not None:
+            # TODO avoid copying the 'src' and 'dst' columns twice
+            gdf = input_graph.view_edge_list().copy()
+            gdf["weight"] = cupy.full(len(gdf), default_value)
+            g.from_cudf_edgelist(
+                gdf, source="src", destination="dst", edge_attr="weight"
+            )
         else:
-            nodes = graph.nodes.copy()
-        return CuGraph(new_g, nodes)
+            offset_col, index_col, _ = g.view_adj_list()
+            value_col = cudf.Series(cupy.full(len(offset_col), default_value))
+            g.from_cudf_adjlist(offset_col, index_col, value_col)
+        return g
+
+    @concrete_algorithm("util.edgemap.from_edgeset")
+    def cugraph_edge_map_from_edgeset(
+        edgeset: CuGraphEdgeSet, default_value: Any,
+    ) -> CuGraphEdgeMap:
+        g = _assign_uniform_weight(edgeset.value, default_value)
+        return CuGraphEdgeMap(g)
 
     @concrete_algorithm("util.graph.assign_uniform_weight")
     def cugraph_graph_assign_uniform_weight(graph: CuGraph, weight: Any) -> CuGraph:
-        new_edges = cugraph_edgemap_from_edgeset.func(graph.edges, weight)
+        new_edges = _assign_uniform_weight(graph.value, weight)
         new_nodes = None if graph.nodes is None else graph.nodes.copy()
-        return CuGraph(new_edges, new_nodes)
+        return CuGraph(new_edges, new_nodes, graph.has_node_weights)
 
     @concrete_algorithm("util.graph.build")
     def cugraph_graph_build(
         edges: mg.Union[CuGraphEdgeSet, CuGraphEdgeMap],
         nodes: mg.Optional[mg.Union[CuDFNodeSet, CuDFNodeMap]],
     ) -> CuGraph:
-        return CuGraph(edges, nodes)
+        return CuGraph(edges.value, nodes.value, isinstance(nodes, CuDFNodeMap))
 
     @concrete_algorithm("bipartite.graph_projection")
     def graph_projection(bgraph: CuGraphBipartiteGraph, nodes_retained: int) -> CuGraph:
@@ -132,27 +132,24 @@ if has_cugraph:
         two_hop_neighbors_df = bgraph.value.get_two_hop_neighbors()
         nodes_to_keep = bgraph.value.sets()[nodes_retained]
         keep_mask = two_hop_neighbors_df.first.isin(nodes_to_keep)
-        # TODO reset_index is workaround for https://github.com/rapidsai/cugraph/issues/1080
-        edge_list_df = two_hop_neighbors_df[keep_mask].reset_index()
+        edge_list_df = two_hop_neighbors_df[keep_mask]
         g.from_cudf_edgelist(edge_list_df, source="first", destination="second")
-        return CuGraph(g, nodes=CuDFNodeSet(nodes_to_keep))
+        nodes = nodes_to_keep.set_index(nodes_to_keep)
+        return CuGraph(g, nodes=nodes)
 
     @concrete_algorithm("clustering.louvain_community")
     def cugraph_louvain_community(graph: CuGraph) -> Tuple[CuDFNodeMap, float]:
-        label_df, modularity_score = cugraph.louvain(graph.edges.value)
-        label_df = label_df.set_index("vertex")
-        if graph.nodes is not None:
-            orphan_mask: cupy.ndarray = ~graph.nodes.value.index.isin(label_df.index)
-            orphan_nodes = graph.nodes.value.index[orphan_mask]
-            orphan_count = orphan_mask.astype(int).sum().item()
-            max_label = label_df.index.max()
-            orphan_labels = cupy.arange(max_label + 1, max_label + 1 + orphan_count)
-            orphan_df = cudf.Series(orphan_labels, index=orphan_nodes).to_frame(
-                "partition"
-            )
-            label_df = cudf.concat([label_df, orphan_df])
-            # TODO this should worsen the modularity score as well.
+        label_df, modularity_score = cugraph.louvain(graph.value)
+        label_series = label_df.set_index("vertex")["partition"]
+        orphan_mask: cupy.ndarray = ~graph.nodes.index.isin(label_series.index)
+        orphan_nodes = graph.nodes.index[orphan_mask]
+        orphan_count = orphan_mask.astype(int).sum().item()
+        max_label = label_df.index.max()
+        orphan_labels = cupy.arange(max_label + 1, max_label + 1 + orphan_count)
+        orphan_series = cudf.Series(orphan_labels, index=orphan_nodes)
+        label_series = cudf.concat([label_series, orphan_series])
+        # TODO more orphan should worsen the modularity score but do not in this implementation
         return (
-            CuDFNodeMap(label_df, "partition"),
+            CuDFNodeMap(label_series),
             modularity_score,
         )

--- a/metagraph_cuda/plugins/cugraph/types.py
+++ b/metagraph_cuda/plugins/cugraph/types.py
@@ -13,7 +13,7 @@ from metagraph.types import (
     EdgeMap,
 )
 from .. import has_cugraph
-from typing import List, Set, Dict, Any, Optional
+from typing import List, Set, Tuple, Dict, Any, Optional
 
 if has_cugraph:
     import cugraph
@@ -108,11 +108,14 @@ if has_cugraph:
                 # slow properties, only compute if asked
                 slow_props = props - ret.keys()
                 if "has_negative_weights" in slow_props:
-                    if obj.value.edgelist:
-                        weights = obj.value.view_edge_list().weights
+                    if ret["dtype"] == "bool":
+                        ret["has_negative_weights"] = None
                     else:
-                        weights = obj.value.view_adj_list()[2]
-                    ret["has_negative_weights"] = (weights < 0).any()
+                        if obj.value.edgelist:
+                            weights = obj.value.view_edge_list().weights
+                        else:
+                            weights = obj.value.view_adj_list()[2]
+                        ret["has_negative_weights"] = (weights < 0).any()
 
                 return ret
 
@@ -206,10 +209,12 @@ if has_cugraph:
                 f"Node weights not specified.",
             )
             if nodes is None:
-                nodes = graph.nodes().copy()
+                nodes = graph.nodes()
+                nodes = nodes.set_index(nodes)
+            self._assert_instance(nodes, cudf.Series)
             self._assert(
-                graph.nodes().isin(nodes).all(),
-                f"{graph} contains nodes not specified in {nodes}.",
+                graph.nodes().isin(nodes.index).all(),
+                f"{graph} contains nodes ({graph.nodes()[~graph.nodes().isin(nodes.index)]}) not specified in {nodes.index.to_arrow().to_pylist()}.",
             )
             self.value = graph
             self.nodes = nodes
@@ -264,7 +269,10 @@ if has_cugraph:
                 slow_props = props - ret.keys()
                 for prop in slow_props:
                     if prop == "edge_has_negative_weights":
-                        ret[prop] = None if weights is None else weights.lt(0).any()
+                        if ret["edge_dtype"] == "bool" or ret["edge_type"] == "set":
+                            ret[prop] = None
+                        else:
+                            ret[prop] = weights.lt(0).any()
 
                 return ret
 
@@ -308,9 +316,6 @@ if has_cugraph:
                         g2_edge_list.columns
                     ), "one of g1 or g2 is weighted while the other is not"
                     columns = list(g1_edge_list.columns)
-                    print(f"columns {repr(columns)}")
-                    print(f"g1_edge_list {repr(g1_edge_list)}")
-                    print(f"g2_edge_list {repr(g2_edge_list)}")
                     # TODO the below takes an additional possibly unneeded O(n) memory
                     assert g1_edge_list.set_index(columns) == g2_edge_list.set_index(
                         columns
@@ -332,31 +337,72 @@ if has_cugraph:
                     assert obj1.nodes.equal(obj2.nodes)
 
     class CuGraphBipartiteGraph(BipartiteGraphWrapper, abstract=BipartiteGraph):
-        def __init__(self, graph):
+        def __init__(
+            self,
+            graph,
+            nodes: Optional[Tuple[cudf.Series, cudf.Series]] = None,
+            nodes0_have_weights: bool = False,
+            nodes1_have_weights: bool = False,
+        ):
             """
             :param graph: cugraph.Graph instance s.t. cugraph.Graph.is_bipartite() returns True
+            :param nodes: Optional tuple of cudf.Series nodes0 and nodes1; indices are node ids and values are nodde weights
             """
             self._assert_instance(graph, cugraph.Graph)
             self._assert(graph.is_bipartite(), f"{graph} is not bipartite")
-            nodes = graph.sets()  # TODO consider storing this as an attribute
-            self._assert(len(nodes) == 2, "nodes must have length of 2")
-            self._assert_instance(nodes[0], cudf.Series)
-            self._assert_instance(nodes[1], cudf.Series)
+
+            graph_node_sets = graph.sets()
+            self._assert(
+                len(graph_node_sets) == 2, "{graph} must have exactly 2 partitions"
+            )
+            self._assert_instance(graph_node_sets[0], cudf.Series)
+            self._assert_instance(graph_node_sets[1], cudf.Series)
             # O(n^2), but cheaper than converting to Python sets
-            common_nodes = nodes[0][nodes[0].isin(nodes[1])]
+            common_nodes = graph_node_sets[0][
+                graph_node_sets[0].isin(graph_node_sets[1])
+            ]
             if len(common_nodes) != 0:
                 raise ValueError(
                     f"Node IDs found in both parts of the graph: {common_nodes.values.tolist()}"
                 )
-            partition_nodes = cudf.concat([nodes[0], nodes[1]])
+            partition_nodes = cudf.concat([graph_node_sets[0], graph_node_sets[1]])
             unclaimed_nodes_mask = ~graph.nodes().isin(partition_nodes)
             if unclaimed_nodes_mask.any():
                 unclaimed_nodes = graph.nodes()[unclaimed_nodes_mask].values.tolist()
                 raise ValueError(
                     f"Node IDs found in graph, but not listed in either partition: {unclaimed_nodes}"
                 )
-            # TODO handle node weights
+
+            nodes0, nodes1 = (None, None) if nodes is None else nodes
+            if nodes0 is None:
+                self._assert(
+                    not nodes0_have_weights,
+                    f"{self.__class__} initialized with node weights for partition 0, but no node weights specified.",
+                )
+                nodes0 = graph_node_sets[0].set_index(graph_node_sets[0])
+            if nodes1 is None:
+                self._assert(
+                    not nodes1_have_weights,
+                    f"{self.__class__} initialized with node weights for partition 1, but no node weights specified.",
+                )
+                nodes1 = graph_node_sets[1].set_index(graph_node_sets[1])
+
+            self._assert_instance(nodes0, cudf.Series)
+            self._assert_instance(nodes1, cudf.Series)
+            self._assert(
+                graph_node_sets[0].isin(nodes0.index).all(),
+                f"Partition 0 of {graph} contains nodes ({graph_node_sets[0][~graph_node_sets[0].isin(nodes0.index)]}) not specified in {nodes0.index.to_arrow().to_pylist()}.",
+            )
+            self._assert(
+                graph_node_sets[1].isin(nodes1.index).all(),
+                f"Partition 1 of {graph} contains nodes ({graph_node_sets[1][~graph_node_sets[1].isin(nodes1.index)]}) not specified in {nodes1.index.to_arrow().to_pylist()}.",
+            )
+
             self.value = graph
+            self.nodes0 = nodes0
+            self.nodes1 = nodes1
+            self.nodes0_have_weights = nodes0_have_weights
+            self.nodes1_have_weights = nodes1_have_weights
 
         class TypeMixin:
             @classmethod
@@ -377,37 +423,51 @@ if has_cugraph:
                         weights = obj.value.view_adj_list()[2]
 
                 # fast properties
-                for prop in {"is_directed", "edge_type", "edge_dtype",} - ret.keys():
+                for prop in {
+                    "is_directed",
+                    "edge_type",
+                    "edge_dtype",
+                    "node0_type",
+                    "node1_type",
+                    "node0_dtype",
+                    "node1_dtype",
+                } - ret.keys():
                     if prop == "is_directed":
                         ret[prop] = obj.value.is_directed()
                     elif prop == "edge_type":
                         ret[prop] = "set" if weights is None else "map"
                     elif prop == "edge_dtype":
-                        ret[prop] = dtypes.dtypes_simplified[weights.dtype]
+                        ret[prop] = (
+                            None
+                            if weights is None
+                            else dtypes.dtypes_simplified[weights.dtype]
+                        )
+                    elif prop == "node0_type":
+                        ret[prop] = "map" if obj.nodes0_have_weights else "set"
+                    elif prop == "node1_type":
+                        ret[prop] = "map" if obj.nodes1_have_weights else "set"
+                    elif prop == "node0_dtype":
+                        ret[prop] = (
+                            dtypes.dtypes_simplified[obj.value.sets()[0].dtype]
+                            if obj.nodes0_have_weights
+                            else None
+                        )
+                    elif prop == "node1_dtype":
+                        ret[prop] = (
+                            dtypes.dtypes_simplified[obj.value.sets()[1].dtype]
+                            if obj.nodes1_have_weights
+                            else None
+                        )
 
                 # slow properties, only compute if asked
                 slow_props = props - ret.keys()
-                if {"node0_dtype", "node1_dtype"} & slow_props:
-                    nodes = obj.value.sets()
-                    if prop == "node0_dtype":
-                        ret[prop] = dtypes.dtypes_simplified[obj.nodes[0].dtype]
-                    elif prop == "node1_dtype":
-                        ret[prop] = dtypes.dtypes_simplified[obj.nodes[1].dtype]
-                slow_props = slow_props - ret.keys()
-                if {
-                    "node0_type",
-                    "node1_type",
-                    "edge_has_negative_weights",
-                } & slow_props:
+                if {"edge_has_negative_weights",} & slow_props:
                     for prop in slow_props:
-                        if prop == "node0_type":
-                            # TODO properly handle when node weights are supported
-                            ret[prop] = "set"
-                        elif prop == "node1_type":
-                            # TODO properly handle when node weights are supported
-                            ret[prop] = "set"
-                        elif prop == "edge_has_negative_weights":
-                            ret[prop] = weights.lt(0).any()
+                        if prop == "edge_has_negative_weights":
+                            if ret["edge_dtype"] == "bool" or ret["edge_type"] == "set":
+                                ret[prop] = None
+                            else:
+                                ret[prop] = weights.lt(0).any()
 
                 return ret
 
@@ -425,27 +485,43 @@ if has_cugraph:
                 abs_tol=0.0,
             ):
                 assert aprops1 == aprops2, f"property mismatch: {aprops1} != {aprops2}"
+                # Compare
+                assert (
+                    obj1.nodes0_have_weights == obj2.nodes0_have_weights
+                ), f"{obj1.nodes0_have_weights} != {obj2.nodes0_have_weights}"
+                assert (
+                    obj1.nodes1_have_weights == obj2.nodes1_have_weights
+                ), f"{obj1.nodes1_have_weights} != {obj2.nodes1_have_weights}"
+
+                assert len(obj1.nodes0) == len(
+                    obj2.nodes0
+                ), f"{len(obj1.nodes0)} == {len(obj2.nodes0)}"
+                assert len(obj1.nodes1) == len(
+                    obj2.nodes1
+                ), f"{len(obj1.nodes1)} == {len(obj2.nodes1)}"
+
+                assert all(
+                    obj1.nodes0.index.isin(obj2.nodes0.index)
+                ), f"{obj1.nodes0} != {obj2.nodes0}"
+                assert all(
+                    obj1.nodes1.index.isin(obj2.nodes1.index)
+                ), f"{obj1.nodes1} != {obj2.nodes1}"
+
+                if aprops1.get("node0_type") == "map":
+                    assert all(
+                        obj1.nodes0 == obj2.nodes0.loc[obj1.nodes0.index]
+                    ), f"{obj1.nodes0} != {obj2.nodes0}"
+                if aprops1.get("node1_type") == "map":
+                    assert all(
+                        obj1.nodes1 == obj2.nodes1.loc[obj1.nodes1.index]
+                    ), f"{obj1.nodes1} != {obj2.nodes1}"
+
                 g1 = obj1.value
                 g2 = obj2.value
-                canonicalize_nodes = lambda series: series.set_index(series)
-                obj1_nodes = [canonicalize_nodes(nodes) for nodes in obj1.value.sets()]
-                obj2_nodes = [canonicalize_nodes(nodes) for nodes in obj2.value.sets()]
-                # Compare
-                assert len(obj1_nodes[0]) == len(
-                    obj2_nodes[0]
-                ), f"{len(obj1_nodes[0])} == {len(obj2_nodes[0])}"
-                assert len(obj1_nodes[1]) == len(
-                    obj2_nodes[1]
-                ), f"{len(obj1_nodes[1])} == {len(obj2_nodes[1])}"
-                assert all(
-                    obj1_nodes[0] == obj2_nodes[0]
-                ), f"{obj1_nodes[0]} != {obj2_nodes[0]}"
-                assert all(
-                    obj1_nodes[1] == obj2_nodes[1]
-                ), f"{obj1_nodes[1]} != {obj2_nodes[1]}"
                 assert (
                     g1.number_of_edges() == g2.number_of_edges()
                 ), f"{g1.number_of_edges()} != {g2.number_of_edges()}"
+
                 if g1.edgelist:
                     g1_edge_list = g1.view_edge_list()
                     g2_edge_list = g2.view_edge_list()
@@ -474,9 +550,3 @@ if has_cugraph:
                                 assert all(
                                     g1_series == g2_series
                                 ), "g1 and g2 have different edges"
-
-                if aprops1.get("node0_type") == "map":
-                    pass  # TODO handle this when node weights are supported
-
-                if aprops1.get("node1_type") == "map":
-                    pass  # TODO handle this when node weights are supported

--- a/metagraph_cuda/plugins/cugraph/types.py
+++ b/metagraph_cuda/plugins/cugraph/types.py
@@ -346,7 +346,7 @@ if has_cugraph:
         ):
             """
             :param graph: cugraph.Graph instance s.t. cugraph.Graph.is_bipartite() returns True
-            :param nodes: Optional tuple of cudf.Series nodes0 and nodes1; indices are node ids and values are nodde weights
+            :param nodes: Optional tuple of cudf.Series nodes0 and nodes1; indices are node ids and values are node weights
             """
             self._assert_instance(graph, cugraph.Graph)
             self._assert(graph.is_bipartite(), f"{graph} is not bipartite")

--- a/metagraph_cuda/plugins/cugraph/types.py
+++ b/metagraph_cuda/plugins/cugraph/types.py
@@ -363,7 +363,7 @@ if has_cugraph:
             ]
             if len(common_nodes) != 0:
                 raise ValueError(
-                    f"Node IDs found in both parts of the graph: {common_nodes.values.tolist()}"
+                    f"Node IDs found in both partitions of the graph: {common_nodes.values.tolist()}"
                 )
             partition_nodes = cudf.concat([graph_node_sets[0], graph_node_sets[1]])
             unclaimed_nodes_mask = ~graph.nodes().isin(partition_nodes)

--- a/metagraph_cuda/tests/translators/test_from_cugraph_translators.py
+++ b/metagraph_cuda/tests/translators/test_from_cugraph_translators.py
@@ -325,14 +325,21 @@ def test_cugraph_graph_to_scipy_graph():
         cdf, source="Source", destination="Destination",
     )
     cudf_nodes = dpr.wrappers.NodeSet.CuDFNodeSet(cudf.Series(range(5)))
-    x = dpr.wrappers.Graph.CuGraph(g)
+    x = dpr.wrappers.Graph.CuGraph(g, cudf.Series(range(5)), False)
 
     scipy_sparse_matrix = ss.csr_matrix(
-        np.array([[0, 1, 1, 0], [0, 0, 1, 0], [1, 0, 0, 0], [0, 0, 1, 0],])
+        np.array(
+            [
+                [0, 1, 1, 0, 0],
+                [0, 0, 1, 0, 0],
+                [1, 0, 0, 0, 0],
+                [0, 0, 1, 0, 0],
+                [0, 0, 0, 0, 0],
+            ]
+        )
     )
-    ss_edge_set = dpr.wrappers.EdgeSet.ScipyEdgeSet(scipy_sparse_matrix)
-    np_nodes = dpr.wrappers.NodeSet.NumpyNodeSet(np.arange(5))
-    intermediate = dpr.wrappers.Graph.ScipyGraph(ss_edge_set, np_nodes)
+    np_nodes = np.arange(5)
+    intermediate = dpr.wrappers.Graph.ScipyGraph(scipy_sparse_matrix, np_nodes)
 
     y = dpr.translate(x, ScipyGraph)
     dpr.assert_equal(y, intermediate)

--- a/metagraph_cuda/tests/translators/test_from_cugraph_translators.py
+++ b/metagraph_cuda/tests/translators/test_from_cugraph_translators.py
@@ -335,7 +335,8 @@ def test_cugraph_graph_to_scipy_graph():
                 [1, 0, 0, 0, 0],
                 [0, 0, 1, 0, 0],
                 [0, 0, 0, 0, 0],
-            ]
+            ],
+            dtype=bool,
         )
     )
     np_nodes = np.arange(5)

--- a/metagraph_cuda/tests/translators/test_intra_metagraph_cuda_translators.py
+++ b/metagraph_cuda/tests/translators/test_intra_metagraph_cuda_translators.py
@@ -11,8 +11,8 @@ def test_cudf_node_map_to_cudf_node_set():
     dpr = mg.resolver
     keys = [3, 2, 1]
     values = [33, 22, 11]
-    map_data = cudf.DataFrame({"key": keys, "val": values}).set_index("key")
-    x = dpr.wrappers.NodeMap.CuDFNodeMap(map_data, "val")
+    map_data = cudf.Series(values).set_index(keys)
+    x = dpr.wrappers.NodeMap.CuDFNodeMap(map_data)
 
     nodes = cudf.Series([3, 1, 2])
     intermediate = dpr.wrappers.NodeSet.CuDFNodeSet(nodes)

--- a/metagraph_cuda/tests/translators/test_to_cudf_translators.py
+++ b/metagraph_cuda/tests/translators/test_to_cudf_translators.py
@@ -121,8 +121,8 @@ def test_numpy_node_map_to_cudf_node_map():
 
     keys = [0, 1, 2]
     labels = [33, 22, 11]
-    cdf_unwrapped = cudf.DataFrame({"key": keys, "label": labels}).set_index("key")
-    intermediate = dpr.wrappers.NodeMap.CuDFNodeMap(cdf_unwrapped, "label")
+    cdf_unwrapped = cudf.Series(labels).set_index(keys)
+    intermediate = dpr.wrappers.NodeMap.CuDFNodeMap(cdf_unwrapped)
     y = dpr.translate(x, CuDFNodeMap)
     dpr.assert_equal(y, intermediate)
     assert len(dpr.plan.translate(x, CuDFNodeMap)) == 1
@@ -130,13 +130,12 @@ def test_numpy_node_map_to_cudf_node_map():
 
 def test_python_node_map_to_cudf_node_map():
     dpr = mg.resolver
-    python_data = {1: 11, 2: 22, 3: 33}
-    x = dpr.wrappers.NodeMap.PythonNodeMap(python_data)
+    x = {1: 11, 2: 22, 3: 33}
 
     keys = [1, 2, 3]
     labels = [11, 22, 33]
-    cdf_unwrapped = cudf.DataFrame({"key": keys, "label": labels}).set_index("key")
-    intermediate = dpr.wrappers.NodeMap.CuDFNodeMap(cdf_unwrapped, "label")
+    cdf_unwrapped = cudf.Series(labels).set_index(keys)
+    intermediate = dpr.wrappers.NodeMap.CuDFNodeMap(cdf_unwrapped)
     y = dpr.translate(x, CuDFNodeMap)
     dpr.assert_equal(y, intermediate)
     assert len(dpr.plan.translate(x, CuDFNodeMap)) == 1
@@ -144,8 +143,7 @@ def test_python_node_map_to_cudf_node_map():
 
 def test_python_node_set_to_cudf_node_set():
     dpr = mg.resolver
-    python_data = {3, 4, 2, 1}
-    x = dpr.wrappers.NodeSet.PythonNodeSet(python_data)
+    x = {3, 4, 2, 1}
 
     intermediate = dpr.wrappers.NodeSet.CuDFNodeSet(cudf.Series([2, 3, 4, 1]))
     y = dpr.translate(x, CuDFNodeSet)

--- a/metagraph_cuda/tests/translators/test_to_cugraph_translators.py
+++ b/metagraph_cuda/tests/translators/test_to_cugraph_translators.py
@@ -235,14 +235,22 @@ def test_scipy_graph_to_cugraph_graph():
 
     +-+  <--  +-+       +-+
     |0|       |2|  <--  |3|
-    +-+  -->  +-+       +-+"""
+    +-+  -->  +-+       +-+
+    """
     dpr = mg.resolver
     scipy_sparse_matrix = ss.csr_matrix(
-        np.array([[0, 1, 1, 0], [0, 0, 1, 0], [1, 0, 0, 0], [0, 0, 1, 0],])
+        np.array(
+            [
+                [0, 1, 1, 0, 0],
+                [0, 0, 1, 0, 0],
+                [1, 0, 0, 0, 0],
+                [0, 0, 1, 0, 0],
+                [0, 0, 0, 0, 0],
+            ],
+            dtype=bool,
+        )
     )
-    ss_edge_set = dpr.wrappers.EdgeSet.ScipyEdgeSet(scipy_sparse_matrix)
-    np_nodes = dpr.wrappers.NodeSet.NumpyNodeSet(np.arange(5))
-    x = dpr.wrappers.Graph.ScipyGraph(ss_edge_set, np_nodes)
+    x = dpr.wrappers.Graph.ScipyGraph(scipy_sparse_matrix, np.arange(5))
 
     sources = [0, 0, 1, 2, 3]
     destinations = [1, 2, 2, 0, 2]
@@ -251,8 +259,7 @@ def test_scipy_graph_to_cugraph_graph():
     g.from_cudf_edgelist(
         cdf, source="Source", destination="Destination",
     )
-    cudf_nodes = dpr.wrappers.NodeSet.CuDFNodeSet(cudf.Series(range(5)))
-    intermediate = dpr.wrappers.Graph.CuGraph(g)
+    intermediate = dpr.wrappers.Graph.CuGraph(g, cudf.Series(range(5)))
 
     y = dpr.translate(x, CuGraph)
     dpr.assert_equal(y, intermediate)


### PR DESCRIPTION
This PR does the following:
* Makes `metagraph-cuda` pass its own tests, the MultiVerify tests, and the roundtrip tests.
* Updates the `metagraph-cuda` to cooperate with the latest roundtriper changes.
* Adds node weight support for `CuGraph` and `CuGraphBipartiteGraph`.